### PR TITLE
Preserve signatures during visit editing

### DIFF
--- a/antiplaga-techpanel-main/src/pages/Home.tsx
+++ b/antiplaga-techpanel-main/src/pages/Home.tsx
@@ -81,8 +81,8 @@ const Home: React.FC = () => {
             bugsCaptured: vals.map(x => ({ bug: x.bug, quantity: x.quantity }))
           })).value(),
       comment: v.comments,
-      signatureClient: "",
-      signatureTechnical: "",
+      signatureClient: (v as any).signatureClient || (v as any).signature_client,
+      signatureTechnical: (v as any).signatureTechnical || (v as any).signature_technical,
       documents: (v.documents as any[]).map(d => ({
         base64image: d.base64 as string,
         type: d.type

--- a/antiplaga-techpanel-main/src/pages/NewVisit/VisitDashboard.tsx
+++ b/antiplaga-techpanel-main/src/pages/NewVisit/VisitDashboard.tsx
@@ -86,10 +86,11 @@ const VisitDashboard: React.FC = () => {
     const missingSteps   = useMemo(() => getMissingSteps(), [visitCreation, getMissingSteps]);
 
     const handleSaveVisit = async () => {
-        const missing = getMissingSteps().filter(step => 
-            step !== 'Observaciones' && 
-            step !== 'Firma Cliente' && 
-            step !== 'Documentos'
+        const missing = getMissingSteps().filter(step =>
+            step !== 'Observaciones' &&
+            step !== 'Firma Cliente' &&
+            step !== 'Documentos' &&
+            (visitCreation.id ? step !== 'Firma Técnico' : true)
         );
         
         if (missing.length > 0) {

--- a/antiplaga-techpanel-main/src/store/visitsStore.ts
+++ b/antiplaga-techpanel-main/src/store/visitsStore.ts
@@ -500,7 +500,7 @@ export const useVisitsStore = create<VisitsStore>()(
                     if (!anyR) missing.push("Roedores");
                 }
                 if (!v.documents?.length) missing.push("Documentos");
-                if (!v.signatureTechnical) missing.push("Firma Técnico");
+                if (!v.signatureTechnical && !v.id) missing.push("Firma Técnico");
                 if (!v.number)            missing.push("N° Remito");
 
                 return missing;


### PR DESCRIPTION
## Summary
- Keep existing client and technician signatures when loading a visit from the home dashboard
- Skip technician signature requirement during edit mode
- Allow editing visits without prompting for missing technician signature

## Testing
- `npm run test.unit` *(fails: Failed to load url setupTests.ts)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c82d7795448326aab6d8626ba7355d