### PR TITLE
feat: add monthly visit log

### DIFF
--- a/antiplaga-techpanel-main/src/api/Antiplaga.ts
+++ b/antiplaga-techpanel-main/src/api/Antiplaga.ts
@@ -177,6 +177,23 @@ export default class Antiplaga {
     }
   }
 
+  async getMonthlyVisitLog(userId: number, from: string, to: string): Promise<Result<VisitEntity[]>> {
+    try {
+      const response = await this.authCall(
+        "GET",
+        `/users/${userId}/visits?from=${from}&to=${to}`
+      )
+      return Result.ok<VisitEntity[]>(response.data.visits)
+    } catch (e: any) {
+      if (e.message === "Network Error") {
+        alert("Hemos detectado problemas de conexión")
+        return Result.fail("Hemos detectado problemas de conexión")
+      } else {
+        return Result.fail<VisitEntity[]>(e.response.data.message)
+      }
+    }
+  }
+
   async getLocations(
     spreadsheet_id: number
   ): Promise<Result<LocationEntity[]>> {

--- a/antiplaga-techpanel-main/src/helpers/visitNavigation.ts
+++ b/antiplaga-techpanel-main/src/helpers/visitNavigation.ts
@@ -1,0 +1,45 @@
+import _ from "lodash";
+import { History } from "history";
+import { VisitEntity } from "../models/VisitEntity";
+import { DocumentEntity } from "../models/DocumentEntity";
+import { useCommonStore } from "../store/commonStore";
+import { useVisitsStore } from "../store/visitsStore";
+
+export const goToDashboard = async (v: VisitEntity, history: History) => {
+  const showLoader = useCommonStore.getState().showLoader;
+  const resetVisitCreation = useVisitsStore.getState().resetVisitCreation;
+  const saveSelectedSS = useVisitsStore.getState().saveSelectedSpreadsheet;
+  const saveVisitCreation = useVisitsStore.getState().saveVisitCreation;
+
+  showLoader(true);
+  resetVisitCreation();
+  saveSelectedSS(v.spreadsheet);
+  const obj = {
+    id: v.id,
+    selectedSpreadsheet: v.spreadsheet,
+    type: v.spreadsheet.type,
+    rodentsData: v.rodent_data,
+    inProgress: true,
+    bugsData: _.chain(v.bug_data as any[])
+      .groupBy("location.id")
+      .map(vals => ({
+        location: vals[0].location,
+        bugsCaptured: vals.map(x => ({ bug: x.bug, quantity: x.quantity }))
+      })).value(),
+    comment: v.comments,
+    signatureClient: "",
+    signatureTechnical: "",
+    documents: (v.documents as any[]).map(d => ({
+      base64image: d.base64 as string,
+      type: d.type
+    })) as DocumentEntity[],
+    products: v.products.map((p: any) => ({
+      product: p, dose: p.dose, lotNumber: p.lot_number
+    })),
+    number: v.number,
+    date: v.date
+  };
+  saveVisitCreation(obj);
+  history.push("/new-visit/dashboard");
+  showLoader(false);
+};

--- a/antiplaga-techpanel-main/src/layout/MainRouter.tsx
+++ b/antiplaga-techpanel-main/src/layout/MainRouter.tsx
@@ -9,6 +9,7 @@ import Home from "../pages/Home";
 import Profile from "../pages/Profile";
 import IncidentsPage from "../pages/IncidentsPage";
 import IncidentDetailPage from "../pages/IncidentDetailPage";
+import VisitLog from "../pages/VisitLog";
 import { IonIcon, IonLabel, IonPage, IonRouterOutlet, IonTabBar, IonTabButton, IonTabs } from "@ionic/react";
 import { build, home, person, alertCircle } from "ionicons/icons";
 import { useAuthStore } from "../store/authStore";
@@ -43,6 +44,7 @@ const MainRouter: React.FC = () => {
             <Route exact path="/profile" component={Profile} />
             <Route exact path="/incidents" component={IncidentsPage} />
             <Route exact path="/incidents/:id" component={IncidentDetailPage} />
+            <Route exact path="/visit-log" component={VisitLog} />
             <Redirect exact path="/" to="/home" />
           </IonRouterOutlet>
 

--- a/antiplaga-techpanel-main/src/pages/VisitLog.tsx
+++ b/antiplaga-techpanel-main/src/pages/VisitLog.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from "react";
+import { IonContent, IonHeader, IonItem, IonLabel, IonList, IonPage, IonTitle, IonToolbar } from "@ionic/react";
+import { useHistory } from "react-router";
+import Antiplaga from "../api/Antiplaga";
+import { useAuthStore } from "../store/authStore";
+import { VisitEntity } from "../models/VisitEntity";
+import { goToDashboard } from "../helpers/visitNavigation";
+
+const VisitLog: React.FC = () => {
+  const user = useAuthStore(s => s.user)!;
+  const history = useHistory();
+  const [visits, setVisits] = useState<VisitEntity[]>([]);
+
+  useEffect(() => {
+    (async () => {
+      const api = new Antiplaga();
+      const now = new Date();
+      const from = new Date(now.getFullYear(), now.getMonth(), 1).toISOString().slice(0, 10);
+      const to = new Date(now.getFullYear(), now.getMonth() + 1, 0).toISOString().slice(0, 10);
+      const res = await api.getMonthlyVisitLog(user.id, from, to);
+      if (res.isSuccess) {
+        setVisits(res.getValue()!);
+      }
+    })();
+  }, [user.id]);
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonTitle>Visitas del mes</IonTitle>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent fullscreen>
+        <IonList>
+          {visits.map(v => (
+            <IonItem key={v.id} button onClick={() => goToDashboard(v, history)}>
+              <IonLabel>
+                <h3>{v.spreadsheet?.name} – #{v.number}</h3>
+                <p>{v.date}</p>
+              </IonLabel>
+            </IonItem>
+          ))}
+        </IonList>
+      </IonContent>
+    </IonPage>
+  );
+};
+
+export default VisitLog;


### PR DESCRIPTION
## Summary
- add API endpoint for monthly visit log
- create VisitLog page to display monthly visits
- register VisitLog route and navigation helper

## Testing
- `npm run test.unit` (fails: Failed to load url setupTests.ts)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c82d88a0048326b94aa84bc19b5e72