### PR TITLE
Fix imports after merge in Home page

### DIFF
--- a/antiplaga-techpanel-main/src/pages/Home.tsx
+++ b/antiplaga-techpanel-main/src/pages/Home.tsx
@@ -1,7 +1,7 @@
 import React, {useState, useEffect, useRef} from "react";
 import {
   IonPage, IonHeader, IonToolbar, IonTitle, IonContent, IonImg,
-  IonItemDivider, IonAccordionGroup, IonAccordion, IonItem,
+  IonAccordionGroup, IonAccordion, IonItem,
   IonLabel, IonList, IonButton, IonSpinner, IonCard,
   IonCardHeader, IonCardTitle, IonCardContent, useIonViewWillEnter,
   IonIcon
@@ -132,7 +132,7 @@ const Home: React.FC = () => {
     const res = await api.getLastVisits(user.id);
     if (res.isSuccess) {
       const backend = res.getValue()!;
-              const offline = useVisitsStore.getState().list.filter(v => (v as any).sync_status === "failed");
+      const offline = useVisitsStore.getState().list.filter(v => (v as any).sync_status === "failed");
       setLastVisits([...backend, ...offline]);
     }
   };


### PR DESCRIPTION
## Summary
- remove unused IonItemDivider import from Home page
- correct indentation when rebuilding offline visit list

## Testing
- npm run build *(fails: existing TypeScript errors in multiple files, including missing module declarations and strict typing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68c84fa44c388326bdcd106913fa763a